### PR TITLE
WrenSec Builds - Phase #1 (for wrensec-bom)

### DIFF
--- a/.wren-deploy.rc
+++ b/.wren-deploy.rc
@@ -1,0 +1,3 @@
+export MAVEN_PACKAGE="forgerock-bom"
+export BINTRAY_PACKAGE="wrensec-bom"
+export JFROG_PACKAGE="org/forgerock/commons/forgerock-bom"

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
    information: "Portions copyright [year] [name of copyright owner]".
 
     Copyright 2015 ForgeRock AS.
+    Portions Copyright © 2017 Wren Security. All rights reserved.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -20,11 +21,11 @@
   <artifactId>forgerock-bom</artifactId>
   <version>4.1.1</version>
   <packaging>pom</packaging>
-  <name>ForgeRock Bill Of Materials</name>
-  <description>Common BOM for ForgeRock projects.
+  <name>Wren Security Bill Of Materials</name>
+  <description>Common BOM for Wren Security forks of ForgeRock projects.
     Provides a list of shared and third party dependencies
     which are known to be compatible with each other.</description>
-  <url>http://www.forgerock.com</url>
+  <url>http://wrensecurity.org</url>
 
   <licenses>
     <license>
@@ -36,53 +37,71 @@
   </licenses>
 
   <issueManagement>
-    <system>jira</system>
-    <url>https://bugster.forgerock.org</url>
+    <system>GitHub Issues</system>
+    <url>https://github.com/WrenSecurity/wrensec-bom/issues</url>
   </issueManagement>
 
   <scm>
-    <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-bom.git</connection>
-    <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-bom.git</developerConnection>
-    <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-bom/browse</url>
+    <url>https://github.com/WrenSecurity/wrensec-bom</url>
+    <connection>scm:git:git://github.com/WrenSecurity/wrensec-bom.git</connection>
+    <developerConnection>scm:git:git@github.com:WrenSecurity/wrensec-bom.git</developerConnection>
   </scm>
 
   <distributionManagement>
     <snapshotRepository>
-      <id>forgerock-snapshots</id>
-      <name>ForgeRock Snapshot Repository</name>
-      <url>${forgerockDistMgmtSnapshotsUrl}</url>
+      <id>bintray-wrensecurity-releases</id>
+      <name>Wren Security Snapshot Repository</name>
+      <url>${forgerockDistMgmtSnapshotsUrl}/wrensec-bom/;publish=1</url>
     </snapshotRepository>
 
     <repository>
-      <id>forgerock-staging</id>
-      <name>ForgeRock Release Repository</name>
-      <url>${forgerockDistMgmtReleasesUrl}</url>
+      <id>bintray-wrensecurity-snapshots</id>
+      <name>Wren Security Release Repository</name>
+      <url>${forgerockDistMgmtReleasesUrl}/wrensec-bom/;publish=1</url>
     </repository>
   </distributionManagement>
 
   <!-- (see FAQ at http://maven.apache.org/guides/mini/guide-central-repository-upload.html ) -->
   <repositories>
     <repository>
-      <id>forgerock-staging-repository</id>
-      <name>ForgeRock Release Repository</name>
-      <url>${forgerockDistMgmtReleasesUrl}</url>
+      <id>bintray-wrensecurity-releases</id>
+      <name>Wren Security Release Repository</name>
+      <url>http://dl.bintray.com/wrensecurity/releases</url>
+
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
+
       <releases>
         <enabled>true</enabled>
       </releases>
     </repository>
 
     <repository>
-      <id>forgerock-snapshots-repository</id>
-      <name>ForgeRock Snapshot Repository</name>
-      <url>${forgerockDistMgmtSnapshotsUrl}</url>
+      <id>bintray-wrensecurity-snapshots</id>
+      <name>Wren Security Snapshot Repository</name>
+      <url>http://dl.bintray.com/wrensecurity/snapshots</url>
+
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
+
       <releases>
         <enabled>false</enabled>
+      </releases>
+    </repository>
+
+    <repository>
+      <id>bintray-wrensecurity-forgerock-archive</id>
+      <name>Wren Security Archive for Verified ForgeRock Artifacts</name>
+      <url>http://dl.bintray.com/wrensecurity/forgerock-archive</url>
+
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+
+      <releases>
+        <enabled>true</enabled>
       </releases>
     </repository>
   </repositories>
@@ -91,8 +110,8 @@
     <maven.min.version>3.0.1</maven.min.version>
 
     <!-- Repository Deployment URLs -->
-    <forgerockDistMgmtSnapshotsUrl>http://maven.forgerock.org/repo/snapshots</forgerockDistMgmtSnapshotsUrl>
-    <forgerockDistMgmtReleasesUrl>http://maven.forgerock.org/repo/releases</forgerockDistMgmtReleasesUrl>
+    <forgerockDistMgmtSnapshotsUrl>https://api.bintray.com/maven/wrensecurity/snapshots</forgerockDistMgmtSnapshotsUrl>
+    <forgerockDistMgmtReleasesUrl>https://api.bintray.com/maven/wrensecurity/releases</forgerockDistMgmtReleasesUrl>
 
     <!-- Third party components versions -->
     <assertj.version>2.1.0</assertj.version>
@@ -567,4 +586,40 @@
 
     </dependencies>
   </dependencyManagement>
+  <profiles>
+    <profile>
+      <id>sign</id>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-gpg-plugin</artifactId>
+              <version>1.4</version>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+        <plugins>
+          <!-- We want to sign the artifact, the POM, and all attached artifacts -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <configuration>
+              <passphrase>${gpg.passphrase}</passphrase>
+              <useAgent>true</useAgent>
+            </configuration>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -49,24 +49,24 @@
 
   <distributionManagement>
     <snapshotRepository>
-      <id>bintray-wrensecurity-releases</id>
+      <id>wrensecurity-snapshots</id>
       <name>Wren Security Snapshot Repository</name>
-      <url>${forgerockDistMgmtSnapshotsUrl}/wrensec-bom/;publish=1</url>
+      <url>${forgerockDistMgmtSnapshotsUrl}</url>
     </snapshotRepository>
 
     <repository>
-      <id>bintray-wrensecurity-snapshots</id>
+      <id>wrensecurity-releases</id>
       <name>Wren Security Release Repository</name>
-      <url>${forgerockDistMgmtReleasesUrl}/wrensec-bom/;publish=1</url>
+      <url>${forgerockDistMgmtReleasesUrl}</url>
     </repository>
   </distributionManagement>
 
   <!-- (see FAQ at http://maven.apache.org/guides/mini/guide-central-repository-upload.html ) -->
   <repositories>
     <repository>
-      <id>bintray-wrensecurity-releases</id>
+      <id>wrensecurity-releases</id>
       <name>Wren Security Release Repository</name>
-      <url>http://dl.bintray.com/wrensecurity/releases</url>
+      <url>${forgerockDistMgmtReleasesUrl}</url>
 
       <snapshots>
         <enabled>false</enabled>
@@ -78,9 +78,9 @@
     </repository>
 
     <repository>
-      <id>bintray-wrensecurity-snapshots</id>
+      <id>wrensecurity-snapshots</id>
       <name>Wren Security Snapshot Repository</name>
-      <url>http://dl.bintray.com/wrensecurity/snapshots</url>
+      <url>${forgerockDistMgmtSnapshotsUrl}</url>
 
       <snapshots>
         <enabled>true</enabled>
@@ -92,12 +92,12 @@
     </repository>
 
     <repository>
-      <id>bintray-wrensecurity-forgerock-archive</id>
+      <id>wrensecurity-forgerock-archive</id>
       <name>Wren Security Archive for Verified ForgeRock Artifacts</name>
-      <url>http://dl.bintray.com/wrensecurity/forgerock-archive</url>
+      <url>${forgerockVerifiedArchiveUrl}</url>
 
       <snapshots>
-        <enabled>false</enabled>
+        <enabled>true</enabled>
       </snapshots>
 
       <releases>
@@ -110,8 +110,9 @@
     <maven.min.version>3.0.1</maven.min.version>
 
     <!-- Repository Deployment URLs -->
-    <forgerockDistMgmtSnapshotsUrl>https://api.bintray.com/maven/wrensecurity/snapshots</forgerockDistMgmtSnapshotsUrl>
-    <forgerockDistMgmtReleasesUrl>https://api.bintray.com/maven/wrensecurity/releases</forgerockDistMgmtReleasesUrl>
+    <forgerockDistMgmtSnapshotsUrl>https://wrensecurity.jfrog.io/wrensecurity/snapshots</forgerockDistMgmtSnapshotsUrl>
+    <forgerockDistMgmtReleasesUrl>https://wrensecurity.jfrog.io/wrensecurity/releases</forgerockDistMgmtReleasesUrl>
+    <forgerockVerifiedArchiveUrl>http://dl.bintray.com/wrensecurity/forgerock-archive</forgerockVerifiedArchiveUrl>
 
     <!-- Third party components versions -->
     <assertj.version>2.1.0</assertj.version>


### PR DESCRIPTION
- modifies the POMs to build using Wren's repos.
- adds GPG signing.
- updates branding to call this Wren Security Bill Of Materials instead of ForgeRock Bill Of Materials.
- adds [Wren Deploy](https://github.com/WrenSecurity/wrensec-deploy-tool) RC file.
- the `sustaining/*` branches have already been updated with similar changes.